### PR TITLE
Fixed eth_getBlockReceipts param conversion

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	ethstore "github.com/gobitfly/eth.store"
-	"github.com/gobitfly/eth.store/version"
+	ethstore "github.com/SergeevDmitry/eth.store"
+	"github.com/SergeevDmitry/eth.store/version"
 	"github.com/shopspring/decimal"
 )
 

--- a/ethstore.go
+++ b/ethstore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	gethRPC "github.com/ethereum/go-ethereum/rpc"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"
@@ -644,7 +645,7 @@ func batchRequestReceipts(ctx context.Context, elClient *gethRPC.Client, txHashe
 func requestReceipts(ctx context.Context, elClient *gethRPC.Client, blockNumber uint64) ([]*TxReceipt, error) {
 	txReceipts := make([]*TxReceipt, 0)
 
-	ioErr := elClient.CallContext(ctx, &txReceipts, "eth_getBlockReceipts", blockNumber)
+	ioErr := elClient.CallContext(ctx, &txReceipts, "eth_getBlockReceipts", rpc.BlockNumberOrHashWithNumber(gethRPC.BlockNumber(blockNumber)))
 	if ioErr != nil {
 		return nil, fmt.Errorf("io-error when fetching tx-receipts: %w", ioErr)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gobitfly/eth.store
+module github.com/SergeevDmitry/eth.store
 
 go 1.20
 


### PR DESCRIPTION
According to this [line](https://github.com/ethereum/go-ethereum/blob/v1.13.10/ethclient/ethclient.go#L114) in the go-ethereum repo, `eth_getBlockReceipts` accepts parameter of string type.

Currently this call produces `json: cannot unmarshal number into Go value of type string` error.

This PR fixes it