### PR TITLE
fix: Use hex string for blockNumber param in eth_getBlockReceipts

### DIFF
--- a/ethstore.go
+++ b/ethstore.go
@@ -643,8 +643,8 @@ func batchRequestReceipts(ctx context.Context, elClient *gethRPC.Client, txHashe
 
 func requestReceipts(ctx context.Context, elClient *gethRPC.Client, blockNumber uint64) ([]*TxReceipt, error) {
 	txReceipts := make([]*TxReceipt, 0)
-
-	ioErr := elClient.CallContext(ctx, &txReceipts, "eth_getBlockReceipts", blockNumber)
+	blockNumberHex := fmt.Sprintf("0x%x", blockNumber)
+	ioErr := elClient.CallContext(ctx, &txReceipts, "eth_getBlockReceipts", blockNumberHex)
 	if ioErr != nil {
 		return nil, fmt.Errorf("io-error when fetching tx-receipts: %w", ioErr)
 	}


### PR DESCRIPTION
This eth method `eth_getBlockReceipts` needs a hex string value block number as the first parameter.

Before this code is fixed, this error will occur.
```
2024/03/11 10:17:41 error doing requestReceipts for slot 43215: io-error when fetching tx-receipts: invalid argument 0: json: cannot unmarshal number into Go value of type string
```