### PR TITLE
fix: correctly interpret BaseFeePerGas as big-endian

### DIFF
--- a/ethstore.go
+++ b/ethstore.go
@@ -488,13 +488,7 @@ func Calculate(ctx context.Context, bnAddress, elAddress, dayStr string, concurr
 					totalTxFee.Add(totalTxFee, txFee)
 				}
 
-				// base fee per gas is stored little-endian but we need it
-				// big-endian for big.Int.
-				var baseFeePerGasBEBytes [32]byte
-				for i := 0; i < 32; i++ {
-					baseFeePerGasBEBytes[i] = blockData.BaseFeePerGas[32-1-i]
-				}
-				baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
+				baseFeePerGas := new(big.Int).SetBytes(blockData.BaseFeePerGas[:])
 				burntFee := new(big.Int).Mul(baseFeePerGas, new(big.Int).SetUint64(blockData.GasUsed))
 
 				totalTxFee.Sub(totalTxFee, burntFee)


### PR DESCRIPTION
Before the fix, `blockData.BaseFeePerGas` was `[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7]`, and `baseFeePerGas` would be `3166189940082864718613269121331309980362851143201109172953918312716374638592.`